### PR TITLE
gsk/gl: don't cache Cairo textures

### DIFF
--- a/gsk/gl/gskglrenderjob.c
+++ b/gsk/gl/gskglrenderjob.c
@@ -1174,20 +1174,9 @@ gsk_gl_render_job_visit_as_fallback (GskGLRenderJob      *job,
   cairo_surface_t *rendered_surface;
   cairo_t *cr;
   int texture_id;
-  GskTextureKey key;
 
   if (surface_width <= 0 || surface_height <= 0)
     return;
-
-  key.pointer = node;
-  key.pointer_is_child = FALSE;
-  key.scale_x = scale_x;
-  key.scale_y = scale_y;
-
-  texture_id = gsk_gl_driver_lookup_texture (job->driver, &key);
-
-  if (texture_id != 0)
-    goto done;
 
   /* We first draw the recording surface on an image surface,
    * just because the scaleY(-1) later otherwise screws up the
@@ -1256,8 +1245,6 @@ gsk_gl_render_job_visit_as_fallback (GskGLRenderJob      *job,
   g_object_unref (texture);
   cairo_surface_destroy (surface);
   cairo_surface_destroy (rendered_surface);
-
-  gsk_gl_driver_cache_texture (job->driver, &key, texture_id);
 
 done:
   if (scale_x < 0 || scale_y < 0)


### PR DESCRIPTION
This never worked in the first place, since we used to evict cached textures at the end of every frame anyway.
    
Now that we don't, this does not work because you can't use the memory address of a render node as the cache key. This is because of two reasons:
    
a) The same render node address can be reused for different Cairo contents b) Render nodes are destroyed and recreated almost every frame (bad!)
    
Since this just causes Cairo cached content to occassionally flicker and show old data, I'm getting rid of it for now. I'll figure out a better way.